### PR TITLE
FakePlayer and TextureManager related fixes

### DIFF
--- a/src/main/java/trollogyadherent/offlineauth/event/ClientEventListener.java
+++ b/src/main/java/trollogyadherent/offlineauth/event/ClientEventListener.java
@@ -285,9 +285,7 @@ public class ClientEventListener {
             return;
         }
 
-        if (OfflineAuth.varInstanceClient.textureManager == null) {
-            OfflineAuth.varInstanceClient.textureManager = Minecraft.getMinecraft().getTextureManager();
-        }
+        OfflineAuth.varInstanceClient.getTextureManager();
 
         EntityPlayer entityPlayerMP = e.entityPlayer;
         String displayName = entityPlayerMP.getDisplayName();

--- a/src/main/java/trollogyadherent/offlineauth/gui/skin/GameOverlayGuiHandler.java
+++ b/src/main/java/trollogyadherent/offlineauth/gui/skin/GameOverlayGuiHandler.java
@@ -147,7 +147,7 @@ public class GameOverlayGuiHandler extends GuiIngame {
                                     return;
                                 }
                             }
-                            mc.getTextureManager().bindTexture(OfflineAuth.varInstanceClient.clientRegistry.getTabMenuResourceLocation(displayName));
+                            OfflineAuth.varInstanceClient.getTextureManager().bindTexture(OfflineAuth.varInstanceClient.clientRegistry.getTabMenuResourceLocation(displayName));
                             GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
                             SkinUtil.drawPlayerFaceAuto(xPos, yPos, 8, 8);
                         }

--- a/src/main/java/trollogyadherent/offlineauth/gui/skin/SkinGuiHandler.java
+++ b/src/main/java/trollogyadherent/offlineauth/gui/skin/SkinGuiHandler.java
@@ -105,7 +105,7 @@ public class SkinGuiHandler {
         if (OfflineAuth.varInstanceClient.skinGuiRenderTicker.getCapeObject() == null) {
             return;
         }
-        Minecraft.getMinecraft().getTextureManager().bindTexture(OfflineAuth.varInstanceClient.skinGuiRenderTicker.getCapeObject().getCurrentFrame(e.partialRenderTick));
+        OfflineAuth.varInstanceClient.getTextureManager().bindTexture(OfflineAuth.varInstanceClient.skinGuiRenderTicker.getCapeObject().getCurrentFrame(e.partialRenderTick));
         GL11.glPushMatrix();
         GL11.glTranslatef(0.0F, 0.0F, 0.125F);
         GL11.glRotatef(SkinGuiRenderTicker.angle, SkinGuiRenderTicker.x, SkinGuiRenderTicker.y, SkinGuiRenderTicker.z);

--- a/src/main/java/trollogyadherent/offlineauth/gui/skin/SkinListEntry.java
+++ b/src/main/java/trollogyadherent/offlineauth/gui/skin/SkinListEntry.java
@@ -111,7 +111,7 @@ public class SkinListEntry {
     }
 
     protected void bindIcon() {
-        this.mc.getTextureManager().bindTexture(skinResourceLocation); //bindTexturePackIcon(this.field_148317_a.getTextureManager());
+        OfflineAuth.varInstanceClient.getTextureManager().bindTexture(skinResourceLocation); //bindTexturePackIcon(this.field_148317_a.getTextureManager());
     }
 
     protected boolean func_148310_d()

--- a/src/main/java/trollogyadherent/offlineauth/gui/skin/cape/CapeListEntry.java
+++ b/src/main/java/trollogyadherent/offlineauth/gui/skin/cape/CapeListEntry.java
@@ -106,7 +106,7 @@ public class CapeListEntry {
     }
 
     protected void bindIcon() {
-        this.mc.getTextureManager().bindTexture(capeResourceLocation); //bindTexturePackIcon(this.field_148317_a.getTextureManager());
+        OfflineAuth.varInstanceClient.getTextureManager().bindTexture(capeResourceLocation); //bindTexturePackIcon(this.field_148317_a.getTextureManager());
     }
 
     protected boolean func_148310_d()

--- a/src/main/java/trollogyadherent/offlineauth/mixin/early/serverutilities/MixinPlayerHeadIcon.java
+++ b/src/main/java/trollogyadherent/offlineauth/mixin/early/serverutilities/MixinPlayerHeadIcon.java
@@ -18,6 +18,7 @@ import serverutils.lib.icon.ImageIcon;
 import serverutils.lib.icon.PlayerHeadIcon;
 import serverutils.lib.util.StringUtils;
 import trollogyadherent.offlineauth.Config;
+import trollogyadherent.offlineauth.OfflineAuth;
 import trollogyadherent.offlineauth.clientdata.UsernameCacheClient;
 import trollogyadherent.offlineauth.skin.SkinUtil;
 import static trollogyadherent.offlineauth.skin.SkinUtil.uuidFastCache;
@@ -45,7 +46,7 @@ public class MixinPlayerHeadIcon extends ImageIcon {
 	@Overwrite(remap = false)
 	@SideOnly(Side.CLIENT)
 	public void bindTexture() {
-		Minecraft.getMinecraft().getTextureManager().bindTexture(offlineAuth$getOASkin());
+        OfflineAuth.varInstanceClient.getTextureManager().bindTexture(offlineAuth$getOASkin());
 	}
 	
 	/**

--- a/src/main/java/trollogyadherent/offlineauth/mixin/late/serverutilities/MixinServerUtilitiesPlayerEventHandler.java
+++ b/src/main/java/trollogyadherent/offlineauth/mixin/late/serverutilities/MixinServerUtilitiesPlayerEventHandler.java
@@ -17,6 +17,8 @@ public class MixinServerUtilitiesPlayerEventHandler {
 			, remap = false
 	)
 	private static void onNameFormat(PlayerEvent.NameFormat event, CallbackInfo ci) {
-		ci.cancel();
+        if (ci != null) {
+            ci.cancel();
+        }
 	}
 }

--- a/src/main/java/trollogyadherent/offlineauth/mixin/late/tabfaces/MixinClientUtil.java
+++ b/src/main/java/trollogyadherent/offlineauth/mixin/late/tabfaces/MixinClientUtil.java
@@ -18,6 +18,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import trollogyadherent.offlineauth.OfflineAuth;
 import trollogyadherent.offlineauth.skin.SkinUtil;
 import trollogyadherent.offlineauth.skin.client.ClientSkinUtil;
 
@@ -65,7 +66,7 @@ public class MixinClientUtil {
 	@Overwrite(remap = false)
 	public static void drawPlayerFace(ResourceLocation rl, float xPos, float yPos, float alpha) {
 		if (rl != null) {
-			VarInstanceClient.minecraftRef.getTextureManager().bindTexture(rl);
+            OfflineAuth.varInstanceClient.getTextureManager().bindTexture(rl);
 			GL11.glColor4f(1.0F, 1.0F, 1.0F, alpha);
 			SkinUtil.drawPlayerFaceAuto(xPos, yPos, 8, 8);
 		}

--- a/src/main/java/trollogyadherent/offlineauth/skin/client/ClientSkinUtil.java
+++ b/src/main/java/trollogyadherent/offlineauth/skin/client/ClientSkinUtil.java
@@ -105,11 +105,8 @@ public class ClientSkinUtil {
             OfflineAuth.error("Error loading texture!");
             return;
         }
-        if (OfflineAuth.varInstanceClient.textureManager == null) {
-            OfflineAuth.varInstanceClient.textureManager = Minecraft.getMinecraft().getTextureManager();
-        }
         OfflineTextureObject offlineTextureObject = new ClientSkinUtil.OfflineTextureObject(bufferedImage);
-        OfflineAuth.varInstanceClient.textureManager.loadTexture(resourceLocation, offlineTextureObject);
+        OfflineAuth.varInstanceClient.getTextureManager().loadTexture(resourceLocation, offlineTextureObject);
     }
 
     public static ResourceLocation loadSkinFromCache(String skinName) {

--- a/src/main/java/trollogyadherent/offlineauth/varinstances/client/VarInstanceClient.java
+++ b/src/main/java/trollogyadherent/offlineauth/varinstances/client/VarInstanceClient.java
@@ -22,7 +22,7 @@ public class VarInstanceClient {
     public ServerData selectedServerData;
     public File datafile;
     public ArrayList<OAServerData> OAServerDataCache;
-    public TextureManager textureManager = Minecraft.getMinecraft().getTextureManager();
+    private TextureManager textureManager;
 
     //public ClientPlayerRegistry skinRegistry = new ClientPlayerRegistry();
     //public ClientPlayerRegistry playerRegistry = new ClientPlayerRegistry();
@@ -84,5 +84,12 @@ public class VarInstanceClient {
         if (!keyPairFile.exists()) {
             keyPairFile.mkdirs();
         }
+    }
+
+    public TextureManager getTextureManager() {
+        if (this.textureManager == null) {
+            this.textureManager = Minecraft.getMinecraft().getTextureManager();
+        }
+        return this.textureManager;
     }
 }


### PR DESCRIPTION
I have tried adding this mod as is to my heavily modded private server and encountered multiple critical issues:
1. Server crashed due to onNameFormat being called with null CallbackInfo
2. Server crashed due to Forestry multifarm using FakePlayer in BreakEvent and PlaceEvent
3. Skins were not rendered in menus and in game because textures were apparently registered in one texture manager but attempted to be retrieved from another.

Fixed all of them